### PR TITLE
Set ansible.cfg timeout to 60

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,4 @@ host_key_checking = False
 callback_whitelist = junit
 roles_path = ./ansible/test/integration/targets
 retry_files_enabled = False
+timeout = 60


### PR DESCRIPTION
In my local tests, long test runs can make the persistent connect timeout to
bail out, after creation on play startup works fine. Then on EOS creating
a new persistent connect can take longer than the default 10s, thus the whole
test run fails.