### PR TITLE
Specify ansible_connection=local

### DIFF
--- a/inventory/static
+++ b/inventory/static
@@ -15,13 +15,16 @@ ansible_ssh_user=ubuntu
 ansible_network_os=vyos
 ansible_ssh_user=vyos
 ansible_ssh_pass=vyos
+ansible_connection=local
 
 [vyos:vars]
 ansible_network_os=vyos
 ansible_ssh_user=vyos
 ansible_ssh_pass=vyos
+ansible_connection=local
 
 [eos:vars]
 ansible_network_os=eos
 ansible_ssh_user=admin
 ansible_ssh_pass=admin
+ansible_connection=local


### PR DESCRIPTION
So we can stop using https://github.com/ansible/ansible/blob/devel/test/integration/vyos.yaml (etc) specify the connection type in here.

This is part of the DCI & ansible-test work