### PR TITLE
Disable debug by default

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,3 +1,5 @@
+debug: False
+
 cli:
   transport: cli
   authorize: yes


### PR DESCRIPTION
As we are no longer using the `eos.yaml` files we had an undeclared variable.

Set the default debug to false