### PR TITLE
Rename ovs to openvswitch

### DIFF
--- a/inventory/static
+++ b/inventory/static
@@ -2,13 +2,13 @@
 
 [platform-agnostic-vyos]
 
-[ovs:children]
+[openvswitch:children]
 ovs-xenial
 
 [platform_agnostic:children]
 platform-agnostic-vyos
 
-[ovs:vars]
+[openvswitch:vars]
 ansible_ssh_user=ubuntu
 
 [platform-agnostic-vyos:vars]


### PR DESCRIPTION
Since ansible-test doesn't allow passing playbooks and creates a
dynamic one on the fly, we now do:

ansible-test {{ platform }}

Since platform is ovs, but modules are openvswitch_*, we don't capture
anything.