### PR TITLE
Add a global openvswitch group

### DIFF
--- a/inventory/static
+++ b/inventory/static
@@ -20,6 +20,9 @@ ansible_ssh_user=root
 ansible_ssh_pass=Juniper
 ansible_connection=local
 
+[openvswitch:children]
+openvswitch-xenial
+
 [junos:children]
 junos-vqfx
 


### PR DESCRIPTION
For now it's comprised of openvswitch-xenial, we may add more platforms to it
in the future