### PR TITLE
Replace inventory_hostname for ansible_ssh_host on nxos group

### DIFF
--- a/inventory/static
+++ b/inventory/static
@@ -27,7 +27,7 @@ ansible_ssh_pass=admin
 ansible_ssh_port=8022
 ansible_ssh_host=localhost
 ansible_network_os=nxos
-ansible_ssh_common_args='-o PubkeyAuthentication=no -o ProxyCommand="ssh -l fedora -W %h:%p {{ inventory_hostname }}"'
+ansible_ssh_common_args='-o PubkeyAuthentication=no -o ProxyCommand="ssh -l fedora -W %h:%p {{ ansible_ssh_host }}"'
 
 [net-vyos-1.1.7:vars]
 ansible_network_os=vyos


### PR DESCRIPTION
Tests are failing due to inventory_hostname been UUIDs.