### PR TITLE
Remove ssh_common_args PubkeyAuthentication from nxos vars

### DIFF
--- a/inventory/static
+++ b/inventory/static
@@ -26,7 +26,6 @@ ansible_ssh_user=admin
 ansible_ssh_pass=admin
 ansible_ssh_port=8022
 ansible_network_os=nxos
-ansible_ssh_common_args='-o PubkeyAuthentication=no'
 
 [net-vyos-1.1.7:vars]
 ansible_network_os=vyos


### PR DESCRIPTION
This is not used anyways, as we use Paramiko.