### PR TITLE
Add nxos and eos group_vars

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -3,9 +3,3 @@ debug: False
 cli:
   transport: cli
   authorize: yes
-
-eapi:
-  transport: eapi
-  use_ssl: no
-  port: 80
-  authorize: yes

--- a/inventory/group_vars/eos.yaml
+++ b/inventory/group_vars/eos.yaml
@@ -1,0 +1,5 @@
+eapi:
+  transport: eapi
+  use_ssl: no
+  port: 80
+  authorize: yes

--- a/inventory/group_vars/nxos.yaml
+++ b/inventory/group_vars/nxos.yaml
@@ -1,0 +1,4 @@
+nxapi:
+  transport: nxapi
+  use_ssl: no
+  port: 8080


### PR DESCRIPTION
The eapi provider should be in eos, adding nxos group vars as well
as there is an impending change for removing altogether ansible/ansible
integration tests group_vars.