### PR TITLE
Fix nxos CLI provider due to containing authorize

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,5 +1,1 @@
 debug: False
-
-cli:
-  transport: cli
-  authorize: yes

--- a/inventory/group_vars/nxos.yaml
+++ b/inventory/group_vars/nxos.yaml
@@ -1,3 +1,6 @@
+cli:
+  transport: cli
+
 nxapi:
   transport: nxapi
   use_ssl: no


### PR DESCRIPTION
Authorize is not supported on nxos, thus removing it from all
and setting it for nxos group.