### PR TITLE
Add transport to CLI provider for EOS

### DIFF
--- a/inventory/group_vars/eos.yaml
+++ b/inventory/group_vars/eos.yaml
@@ -1,4 +1,5 @@
 cli:
+  transport: cli
   authorize: yes
 
 eapi:


### PR DESCRIPTION
There's a bug in the code where the modules fail if provider is passed
and transport is None.
Fixing this on CI for now to get back to green, real fix should be in
the module code, action plugins most likely.